### PR TITLE
Fix: 회원탈퇴/로그아웃 API 리프레시 토큰 전송 로직 수정 및 URL 변경

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "esModuleInterop": true,
     "jsx": "react-jsx",
     "paths": {
       "@/*": ["./*"]

--- a/types/api.ts
+++ b/types/api.ts
@@ -1883,11 +1883,18 @@ export const logoutAPI = async (): Promise<{
   result: string;
 }> => {
   try {
-    const headers = await getAuthHeadersAsync();
+    const accessToken = await AsyncStorage.getItem("accessToken");
+    const refreshToken = await AsyncStorage.getItem("refreshToken");
 
     const response = await fetch(`${API_BASE_URL}/users/auth/logout`, {
       method: "POST",
-      headers,
+      headers: {
+        "Content-Type": "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+      body: JSON.stringify({
+        refreshToken: refreshToken,
+      }),
     });
 
     if (!response.ok) {

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { API_BASE_URL } from "../config/api";
 import { getAuthHeadersAsync, handleTokenError } from "./auth";
 
@@ -1911,9 +1912,17 @@ export const deleteUserAPI = async (): Promise<{
   try {
     const headers = await getAuthHeadersAsync();
 
+    const refreshToken = await AsyncStorage.getItem("refreshToken");
+
     const response = await fetch(`${API_BASE_URL}/users`, {
       method: "DELETE",
-      headers,
+      headers: {
+        ...headers,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        refreshToken: refreshToken,
+      }),
     });
 
     if (!response.ok) {

--- a/types/api.ts
+++ b/types/api.ts
@@ -903,7 +903,7 @@ export const getReadingSpotsAPI = async (
     const headers = await getAuthHeadersAsync();
 
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot?page=${page}&size=${size}&sort=${sort}`,
+      `${API_BASE_URL}/reading-spots?page=${page}&size=${size}&sort=${sort}`,
       {
         method: "GET",
         headers,
@@ -932,7 +932,7 @@ export const getMyScrapedReadingSpotsAPI = async (
     const headers = await getAuthHeadersAsync();
 
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot/scraps/my?page=${page}&size=${size}`,
+      `${API_BASE_URL}/reading-spots/scraps/my?page=${page}&size=${size}`,
       {
         method: "GET",
         headers,
@@ -961,7 +961,7 @@ export const getMyCreatedReadingSpotsAPI = async (
     const headers = await getAuthHeadersAsync();
 
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot/my?page=${page}&size=${size}`,
+      `${API_BASE_URL}/reading-spots/my?page=${page}&size=${size}`,
       {
         method: "GET",
         headers,
@@ -1023,7 +1023,7 @@ export const createReadingSpotAPI = async (
       formData.append("images", imageFile);
     });
 
-    const response = await fetch(`${API_BASE_URL}/reading-spot`, {
+    const response = await fetch(`${API_BASE_URL}/reading-spots`, {
       method: "POST",
       headers: {
         ...headers,
@@ -2130,12 +2130,12 @@ export const toggleReadingSpotScrapAPI = async (
   console.log("toggleReadingSpotScrapAPI 시작:", readingSpotId);
   console.log(
     "API URL:",
-    `${API_BASE_URL}/reading-spot/${readingSpotId}/scraps`,
+    `${API_BASE_URL}/reading-spots/${readingSpotId}/scraps`,
   );
   try {
     const headers = await getAuthHeadersAsync();
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot/${readingSpotId}/scraps`,
+      `${API_BASE_URL}/reading-spots/${readingSpotId}/scraps`,
       {
         method: "POST",
         headers: {
@@ -2168,12 +2168,12 @@ export const toggleReadingSpotLikeAPI = async (
   console.log("toggleReadingSpotLikeAPI 시작:", readingSpotId);
   console.log(
     "API URL:",
-    `${API_BASE_URL}/reading-spot/${readingSpotId}/likes`,
+    `${API_BASE_URL}/reading-spots/${readingSpotId}/likes`,
   );
   try {
     const headers = await getAuthHeadersAsync();
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot/${readingSpotId}/likes`,
+      `${API_BASE_URL}/reading-spots/${readingSpotId}/likes`,
       {
         method: "POST",
         headers: {
@@ -2210,12 +2210,12 @@ export const createReadingSpotCommentAPI = async (
   });
   console.log(
     "API URL:",
-    `${API_BASE_URL}/reading-spot/${readingSpotId}/comments`,
+    `${API_BASE_URL}/reading-spots/${readingSpotId}/comments`,
   );
   try {
     const headers = await getAuthHeadersAsync();
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot/${readingSpotId}/comments`,
+      `${API_BASE_URL}/reading-spots/${readingSpotId}/comments`,
       {
         method: "POST",
         headers: {
@@ -2267,12 +2267,12 @@ export const getReadingSpotCommentListAPI = async (
   });
   console.log(
     "API URL:",
-    `${API_BASE_URL}/reading-spot/${readingSpotId}/comments?page=${page}&size=${size}`,
+    `${API_BASE_URL}/reading-spots/${readingSpotId}/comments?page=${page}&size=${size}`,
   );
   try {
     const headers = await getAuthHeadersAsync();
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot/${readingSpotId}/comments?page=${page}&size=${size}`,
+      `${API_BASE_URL}/reading-spots/${readingSpotId}/comments?page=${page}&size=${size}`,
       {
         method: "GET",
         headers,
@@ -2323,11 +2323,11 @@ export const getBookmarkDetailAPI = async (
   };
 }> => {
   console.log("getBookmarkDetailAPI 시작:", readingSpotId);
-  console.log("API URL:", `${API_BASE_URL}/reading-spot/${readingSpotId}`);
+  console.log("API URL:", `${API_BASE_URL}/reading-spots/${readingSpotId}`);
   try {
     const headers = await getAuthHeadersAsync();
     const response = await fetch(
-      `${API_BASE_URL}/reading-spot/${readingSpotId}`,
+      `${API_BASE_URL}/reading-spots/${readingSpotId}`,
       {
         method: "GET",
         headers,


### PR DESCRIPTION
## #️⃣연관된 이슈
> #12 

## 📝작업 내용
서버 API 명세 변경 사항을 반영.

1. 회원탈퇴 및 로그아웃 API 수정
> deleteUserAPI(회원탈퇴)와 logoutAPI(로그아웃) 호출 시, 요청 Body에 refreshToken을 포함하도록 수정. (서버 요구사항 반영)

2. 토큰 핸들링 방식 변경 (회원탈퇴, 로그아웃)
> AsyncStorage에서 직접 토큰을 조회하도록 적용.

3. API 엔드포인트 URL 수정
> 기존 reading-spot으로 되어있던 API 경로를 reading-spots로 복수형에 맞춰 수정.